### PR TITLE
use yaml aliases for servers

### DIFF
--- a/config/batch.yml
+++ b/config/batch.yml
@@ -1,20 +1,30 @@
-glenn:
+glenn: &glenn
     lib: '/usr/local/torque-2.4.10/lib/libtorque.so'
-    server: 'opt-batch.osc.edu'
+    server: &glenn_server 'opt-batch.osc.edu'
     qsub: 'LD_LIBRARY_PATH=/usr/local/torque-2.4.10/lib:$LD_LIBRARY_PATH /usr/local/torque-2.4.10/bin/qsub'
-oakley:
+*glenn_server:
+  <<: *glenn
+oakley: &oakley
     lib: '/usr/local/torque-4.2.8/lib/libtorque.so'
-    server: 'oak-batch.osc.edu'
+    server: &oakley_server 'oak-batch.osc.edu'
     qsub: 'LD_LIBRARY_PATH=/usr/local/torque-4.2.8/lib:$LD_LIBRARY_PATH /usr/local/torque-4.2.8/bin/qsub'
-ruby:
+*oakley_server:
+  <<: *oakley
+ruby: &ruby
     lib: '/usr/local/torque-4.2.8/lib/libtorque.so'
-    server: 'ruby-batch.ten.osc.edu'
+    server: &ruby_server 'ruby-batch.ten.osc.edu'
     qsub: 'LD_LIBRARY_PATH=/usr/local/torque-4.2.8/lib:$LD_LIBRARY_PATH /usr/local/torque-4.2.8/bin/qsub'
-oxymoron:
+*ruby_server:
+  <<: *ruby
+oxymoron: &oxymoron
     lib: '/usr/local/torque-4.2.8/lib/libtorque.so'
-    server: 'oak-batch.osc.edu:17001'
+    server: &oxymoron_server 'oak-batch.osc.edu:17001'
     qsub: 'LD_LIBRARY_PATH=/usr/local/torque-4.2.8/lib:$LD_LIBRARY_PATH /usr/local/torque-4.2.8/bin/qsub'
-quick:
+*oxymoron_server:
+  <<: *oxymoron
+quick: &quick
     lib: '/usr/local/torque-4.2.8/lib/libtorque.so'
-    server: 'quick-batch.osc.edu'
+    server: &quick_server 'quick-batch.osc.edu'
     qsub: 'LD_LIBRARY_PATH=/usr/local/torque-4.2.8/lib:$LD_LIBRARY_PATH /usr/local/torque-4.2.8/bin/qsub'
+*quick_server:
+  <<: *quick


### PR DESCRIPTION
the config file had convenient keys like "oakley" in place of
"oak-batch.osc.edu"; these aliases are added to give the option of using
the server name as the key instead; so that after you load from YAML
into a hash, you can either do:

```
myhash["oakley"]
```

or

```
myhash["oak-batch.osc.edu"]
```

And you will get the same values.
